### PR TITLE
ci: update Ruby version to 3.3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.1.2
+          ruby-version: 3.3.4
           bundler: 2.3.24
 
       - name: RSpec


### PR DESCRIPTION
Updates the CI configuration to use Ruby 3.3.4 to match the version specified in the Gemfile, fixing the build failure caused by version mismatch.

## Problem
The CI workflow was failing with the error:
```
Your Ruby version is 3.1.2, but your Gemfile specified 3.3.4
```

This occurred because `.github/workflows/ci.yml` was configured to use Ruby 3.1.2 while the project requires Ruby 3.3.4.

## Solution
- Updated `.github/workflows/ci.yml` line 15 to use `ruby-version: 3.3.4`
- This aligns the CI environment with the project's required Ruby version as specified in the Gemfile

## Testing
- CI should now pass successfully as the Ruby version will match between the Gemfile and the CI environment
- No local testing required as this is purely a CI configuration fix
- The fix follows the existing CI workflow structure and only changes the version number

## Changes
- **File**: `.github/workflows/ci.yml`
- **Change**: `ruby-version: 3.1.2` → `ruby-version: 3.3.4`

## References
Fixes the CI build failure that was preventing automated tests from running.